### PR TITLE
Add Jest unit tests

### DIFF
--- a/src/lib/MEDS-DEV/parse_tree.test.ts
+++ b/src/lib/MEDS-DEV/parse_tree.test.ts
@@ -1,0 +1,25 @@
+import { parseTree } from '@site/src/lib/MEDS-DEV/parse_tree';
+import { MedsEntityFlatTree } from '@site/src/lib/MEDS-DEV/types';
+
+type Dummy = { value?: number };
+
+describe('parseTree', () => {
+  it('converts a flat tree to nested structure', () => {
+    const flat: MedsEntityFlatTree<Dummy> = {
+      root: { name: 'root', data: { value: 1 }, children: ['child1', 'child2'] },
+      child1: { name: 'child1', data: { value: 2 }, children: [] },
+      child2: { name: 'child2', data: { value: 3 }, children: [] },
+    };
+    const tree = parseTree(flat);
+    expect(Object.keys(tree)).toEqual(['root']);
+    expect(tree.root.children.child1.data.value).toBe(2);
+    expect(tree.root.children.child2.data.value).toBe(3);
+  });
+
+  it('throws when child is missing', () => {
+    const flat: MedsEntityFlatTree<Dummy> = {
+      root: { name: 'root', data: {}, children: ['missing'] },
+    } as any;
+    expect(() => parseTree(flat)).toThrow('Child key missing not found in data');
+  });
+});

--- a/src/lib/ecosystem/utils.test.ts
+++ b/src/lib/ecosystem/utils.test.ts
@@ -1,0 +1,39 @@
+import { parseCategoryMap, mergeParsedEcosystems } from '@site/src/lib/ecosystem/utils';
+import { RawCategory } from '@site/src/lib/ecosystem/types';
+
+describe('parseCategoryMap', () => {
+  it('handles nested categories and package topics', () => {
+    const data: Record<string, RawCategory> = {
+      root: {
+        name: 'Root',
+        packages: [{ name: 'pkg1' }],
+        child: {
+          name: 'Child',
+          packages: [{ name: 'pkg2' }, { name: 'pkg3', topics: ['extra'] }],
+        } as unknown as RawCategory,
+      },
+    };
+
+    const { packages, topics, topicPackages } = parseCategoryMap(data);
+    expect(Object.keys(packages).sort()).toEqual(['pkg1', 'pkg2', 'pkg3']);
+    expect(Object.keys(topics)).toEqual(expect.arrayContaining(['Root', 'Root/Child', 'extra']));
+    expect(topics['Root/Child'].featured).toEqual(['pkg2', 'pkg3']);
+    expect(topicPackages['Root']).toEqual(['pkg1', 'pkg2', 'pkg3']);
+    expect(topicPackages['Root/Child']).toEqual(['pkg2', 'pkg3']);
+    expect(topicPackages['extra']).toEqual(['pkg3']);
+  });
+});
+
+describe('mergeParsedEcosystems', () => {
+  it('combines packages and topics from multiple ecosystems', () => {
+    const eco1 = parseCategoryMap({ cat1: { name: 'Cat1', packages: [{ name: 'a' }] } });
+    const eco2 = parseCategoryMap({ cat2: { name: 'Cat2', packages: [{ name: 'b' }] } });
+
+    const merged = mergeParsedEcosystems(eco1, eco2);
+
+    expect(Object.keys(merged.packages).sort()).toEqual(['a', 'b']);
+    expect(Object.keys(merged.topics)).toEqual(expect.arrayContaining(['Cat1', 'Cat2']));
+    expect(merged.topicPackages['Cat1']).toEqual(['a']);
+    expect(merged.topicPackages['Cat2']).toEqual(['b']);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for ecosystem utilities
- add tests for MEDS-DEV tree parsing

## Testing
- `npm test --silent`
- `npm run lint`
- `npm run prettier:check`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6876b7b43d90832c9b1c05bda62c1b2d