### PR TITLE
Add MIMIC-IV Demo dataset to ecosystem.yaml

### DIFF
--- a/static/data/ecosystem.yaml
+++ b/static/data/ecosystem.yaml
@@ -81,7 +81,11 @@ dataset_etls:
   publicly_available_datasets:
     name: 'Public Datasets'
     description: 'ETLs for datasets that are open for public use (subject to DUA and license agreements).'
-
+    
+    datasets:
+      - name: 'MIMIC-IV Demo'
+        physionet_repo: https://physionet.org/content/mimic-iv-demo-meds/0.0.1/
+        
     packages:
       - name: 'MIMIC-IV'
         demo_available: true


### PR DESCRIPTION
Added MIMIC-IV Demo dataset information to ecosystem.yaml. Not sure where the allowed yaml keys are defined.