### PR TITLE
ci: deploy to Pages from Actions on tag push

### DIFF
--- a/.github/workflows/code-quality-pr.yaml
+++ b/.github/workflows/code-quality-pr.yaml
@@ -57,3 +57,6 @@ jobs:
         run: |
           echo "Linting..."
           npm run lint -- ${{ steps.changed-files.outputs.all_changed_files }}
+
+      - name: Build site
+        run: npm run build

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,57 @@
+name: Deploy to GitHub Pages
+
+# Triggers a Pages deploy when a new version tag is pushed (e.g. v1.0.0 from
+# `git tag` or from a GitHub Release). Also supports manual dispatch from the
+# Actions tab — useful for re-deploying the latest tag without cutting a new
+# release.
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+# `id-token: write` + `pages: write` are required by actions/deploy-pages.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent Pages deploy. Don't cancel in-progress runs — let
+# them finish so the site isn't left in a half-deployed state.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./build
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -115,12 +115,30 @@ import nb from './converting_to_MEDS.ipynb';
 
 ## Deployment
 
-> [!WARNING] Only do this when you are ready to deploy the site to the public facing page!
+The site auto-deploys to <https://medical-event-data-standard.github.io/> via the
+`Deploy to GitHub Pages` workflow (`.github/workflows/deploy.yaml`) whenever a
+`v*` tag is pushed. To cut a release:
 
-```
-npm run build
-npm run deploy
+```bash
+git tag v0.1.0
+git push origin v0.1.0
 ```
 
-This command generates static content into the `build` directory and can be served using any static contents
-hosting service.
+Or create a GitHub Release in the UI with a new `v*` tag — that pushes the tag
+and triggers the same workflow.
+
+The workflow can also be re-run manually from the Actions tab via `Run workflow`.
+
+### Local build / preview
+
+```bash
+npm run build      # generates ./build
+npm run serve      # serves ./build at http://localhost:3000
+```
+
+### Manual / fallback deploy
+
+`npm run deploy` (which runs `docusaurus deploy`) is still wired up as a fallback
+that publishes from your local checkout to the `gh-pages` branch — but once Pages
+is switched to `GitHub Actions` as its source (see `deploy.yaml`), the manual
+path will no longer move the live site. Use the workflow.


### PR DESCRIPTION
## Summary

Switches the website's deploy story from \"a maintainer remembers to run \`npm run deploy\` from their laptop\" to \"a tag push triggers a Pages deploy from GitHub Actions.\"

### What's in the PR
- **New: \`.github/workflows/deploy.yaml\`** — builds on Node 22, publishes via \`actions/upload-pages-artifact@v3\` + \`actions/deploy-pages@v4\`. Triggers on \`v*\` tag push and \`workflow_dispatch\`. \`concurrency: pages\` (no cancel-in-progress) prevents overlapping runs.
- **\`code-quality-pr.yaml\`:** added an \`npm run build\` step. Without this, a PR could merge clean (lint/prettier/typecheck/jest all green), then a later tag push would surface a Docusaurus build failure on the deploy job — too late. Catching it at PR time keeps \`main\` always-deployable.
- **\`README.md\`:** documents the new flow (tag → deploy) plus the \`npm run deploy\` fallback caveat.

### Trigger choice
Per the request, this fires on **new tag / version**, not on push to \`main\`. Specifically:
- \`push: tags: ['v*']\` — covers \`git tag v0.1.0 && git push origin v0.1.0\` and tags created via the GitHub Release UI.
- \`workflow_dispatch\` — lets a maintainer re-run the deploy from the Actions tab without cutting a new tag.

## ⚠️ Required action before merging (or before the first tag push)

The Pages source must be flipped from **\"Deploy from a branch\" (\`gh-pages\`)** to **\"GitHub Actions\"** in repo Settings → Pages. The workflow cannot do this itself — it requires admin in the UI (or a one-shot \`gh api -X POST repos/.../pages -f build_type=workflow\`). Until that's flipped:
- The workflow will run and produce an artifact, but \`actions/deploy-pages\` will fail because the Pages source still expects a branch.
- The current \`gh-pages\` branch will keep serving stale content.

After flipping, the existing \`gh-pages\` branch can be left alone (harmless) or deleted later.

## Verified locally
- \`npm run prettier:check\` — clean
- \`npm run typecheck\` — clean
- \`npm run test\` — pass
- \`npm run build\` — succeeds

## Test plan
- [ ] CI green on this PR (now includes \`npm run build\` step)
- [ ] After merge to \`dev\` and forward to \`main\`, flip Pages source to \"GitHub Actions\"
- [ ] Push a test tag (e.g. \`v0.1.0-test\`) and confirm the Deploy workflow succeeds and the live site updates
- [ ] Confirm \`workflow_dispatch\` works from the Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)