### PR TITLE
Add EHR-RAGp entry to ecosystem.yaml

### DIFF
--- a/static/data/ecosystem.yaml
+++ b/static/data/ecosystem.yaml
@@ -151,3 +151,7 @@ models:
       github_repo: 'hoon9405/GenHPF'
       pypi_name: 'genhpf'
       MEDS_DEV_name: 'genhpf'
+    - name: 'EHR-RAGp'
+      paper_url: 'https://arxiv.org/abs/2605.12335'
+      github_repo: 'nyuad-cai/EHR-RAGp'
+


### PR DESCRIPTION
This PR adds EHR-RAGp to the MEDS ecosystem page.

EHR-RAGp is a retrieval-augmented foundation model for longitudinal EHR data that combines patient-history retrieval with prototype-guided aggregation for downstream clinical prediction tasks.

Links:

* Paper: https://arxiv.org/abs/2605.12335
* Code: https://github.com/nyuad-cai/EHR-RAGp